### PR TITLE
Synthesise satis packages from GitHub release zips

### DIFF
--- a/.github/workflows/satis.yml
+++ b/.github/workflows/satis.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # Daily 04:30 UTC — picks up new upstream releases for packages declared
+    # in `release-packages.json` (GitHub-released proprietary plugins that
+    # don't have a Genero-owned fork driving satis via the VCS pattern).
+    - cron: '30 4 * * *'
 env:
   BUILD_DIR: build
 
@@ -38,6 +43,14 @@ jobs:
           key: ${{ runner.os }}-php-${{ steps.get-date.outputs.date }}
           restore-keys: ${{ runner.os }}-php-
 
+      - name: Synthesise GitHub-release package entries
+        env:
+          # GitHub-released closed-source plugins live under public repos —
+          # GITHUB_TOKEN is enough; falls back to anonymous (60/h rate limit)
+          # if absent, which is fine since we run at most once a day.
+          GITHUB_TOKEN: ${{ secrets.GENEROI_DEPLOY_PAT || secrets.GITHUB_TOKEN }}
+        run: node generate-release-packages.js satis.json satis.merged.json
+
       - name: Docker pull
         run: docker pull composer/satis
 
@@ -49,14 +62,14 @@ jobs:
             --user $(id -u):$(id -g) \
             --volume $(pwd):/build \
             --volume "${COMPOSER_HOME}:/composer" \
-            composer/satis -vvv build /build/satis.json /build/${{ env.BUILD_DIR }} --no-interaction
+            composer/satis -vvv build /build/satis.merged.json /build/${{ env.BUILD_DIR }} --no-interaction
 
       - name: Rewrite dist URLs for release-based packages
         run: node rewrite-dist-urls.js ${{ env.BUILD_DIR }}
 
       - name: Publish to GitHub pages
         run: |
-          rm composer.json
+          rm composer.json satis.merged.json
           git checkout gh-pages
           rm -rf include/*
           cp -R ${{ env.BUILD_DIR }}/* .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/satis.merged.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # generoi.github.io/packagist
 
-### Add a plugin
+This satis exposes Composer packages for plugins we use across Genero
+projects. There are two distinct mechanisms depending on how upstream
+distributes the plugin:
+
+- **Genero-owned fork (default)** — a `generoi/<slug>` repo holds a
+  curated `composer.json` declaring `type: wordpress-plugin` plus a CI
+  workflow that polls upstream, commits new versions, tags, and triggers
+  a satis rebuild. Listed under `repositories` in [`satis.json`](./satis.json)
+  as `type: vcs`. The release zip URL is rewritten post-build by
+  [`rewrite-dist-urls.js`](./rewrite-dist-urls.js) when entries are present
+  in [`release-dist.json`](./release-dist.json).
+
+- **Direct GitHub-release mirror** — for plugins that already publish
+  signed, prebuilt release zips and don't need a Genero fork (typically
+  open-distribution but closed-source). Listed in
+  [`release-packages.json`](./release-packages.json);
+  [`generate-release-packages.js`](./generate-release-packages.js) runs
+  before satis build, queries the GitHub API for the source repo's
+  releases, and synthesises a `package`-type entry per stable release
+  with `dist.url` pointing at the asset on GitHub. The Satis Build
+  workflow runs daily so new upstream releases get picked up automatically.
+
+### Add a plugin (Genero-owned fork)
 
 1. Create repository with a basic `composer.json`
 
@@ -47,6 +69,42 @@
 6. Trigger an initial build which will download the latest plugin version, commit it, tag it, push it, release it and if successful trigger a rebuild in this repository.
 
 7. Whenever a new version is found using the cron schedule, the plugin will be updated, released and finally a rebuild of this repository will be once again triggered.
+
+### Add a plugin (direct GitHub-release mirror)
+
+Use this when upstream already publishes a versioned release zip on
+GitHub and we don't need a Genero-owned fork (no license key to inject,
+no proprietary metadata, no custom `composer.json`).
+
+1. Verify the upstream repo publishes a stable asset filename on every
+   release (e.g. `altcha.zip` for `altcha-org/altcha-wordpress-next`).
+   Inspect a recent release page to confirm.
+
+2. Add an entry to [`release-packages.json`](./release-packages.json):
+
+    ```json
+    {
+        "altcha-org/altcha": {
+            "source": "altcha-org/altcha-wordpress-next",
+            "asset":  "altcha.zip",
+            "type":   "wordpress-plugin"
+        }
+    }
+    ```
+
+    Optional fields: `homepage`, `require` (applied uniformly to every
+    synthesised version — only useful if upstream's dependency set is
+    stable). `type` defaults to `wordpress-plugin`.
+
+3. Trigger a Satis Build (manually via the Actions tab or just wait for
+   the daily cron at 04:30 UTC). The script enumerates the upstream's
+   releases, synthesises one `package` entry per stable release, and
+   exposes them through this satis under the chosen package name.
+
+4. In the consumer project (Bedrock site, etc.) add the satis as a
+   `composer` repository (already done in agency projects) and
+   `composer require <name>:^<version>` — Composer-installers will route
+   it into `web/app/plugins/<slug>/` via Bedrock's `installer-paths`.
 
 ### Prerequisites
 

--- a/generate-release-packages.js
+++ b/generate-release-packages.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Generates synthetic Satis `package` repository entries for plugins that
+ * publish prebuilt zip releases on GitHub but don't (or can't) live as a
+ * Genero-owned fork with `type: wordpress-plugin` in their composer.json.
+ *
+ * Reads `release-packages.json`:
+ *
+ *   {
+ *     "altcha-org/altcha": {
+ *       "source": "altcha-org/altcha-wordpress-next",
+ *       "asset":  "altcha.zip",
+ *       "type":   "wordpress-plugin"
+ *     }
+ *   }
+ *
+ * For each entry, queries the GitHub API for the source repo's releases,
+ * synthesises one `package` repository per stable release that ships the
+ * named asset, appends them to `satis.json.repositories`, and writes the
+ * merged config to `satis.merged.json` for `composer/satis build` to read.
+ *
+ * Usage: node generate-release-packages.js [satis.json] [output.json]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = __dirname;
+const CONFIG_PATH = path.join(ROOT, 'release-packages.json');
+const SATIS_PATH = process.argv[2] || path.join(ROOT, 'satis.json');
+const OUT_PATH = process.argv[3] || path.join(ROOT, 'satis.merged.json');
+
+const satis = JSON.parse(fs.readFileSync(SATIS_PATH, 'utf8'));
+
+if (!fs.existsSync(CONFIG_PATH)) {
+    fs.writeFileSync(OUT_PATH, JSON.stringify(satis, null, 4));
+    console.log(`No release-packages.json — wrote ${SATIS_PATH} as-is to ${OUT_PATH}.`);
+    process.exit(0);
+}
+
+const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+const token = process.env.GITHUB_TOKEN || process.env.GENEROI_DEPLOY_PAT || '';
+const headers = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'generoi-packagist-build',
+};
+if (token) {
+    headers.Authorization = `Bearer ${token}`;
+}
+
+/**
+ * Fetch all releases for the repo (pages of 100 until exhausted), filtering
+ * out drafts and prereleases. Caps at 5 pages so a misconfigured entry can't
+ * burn the full rate limit budget.
+ */
+async function fetchReleases(repo) {
+    const all = [];
+    for (let page = 1; page <= 5; page++) {
+        const url = `https://api.github.com/repos/${repo}/releases?per_page=100&page=${page}`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) {
+            throw new Error(`GitHub API ${res.status} for ${repo}: ${await res.text()}`);
+        }
+        const batch = await res.json();
+        if (batch.length === 0) break;
+        all.push(...batch);
+        if (batch.length < 100) break;
+    }
+    return all.filter((r) => !r.draft && !r.prerelease);
+}
+
+async function main() {
+    const synthesised = [];
+
+    for (const [name, entry] of Object.entries(config)) {
+        if (!entry.source || !entry.asset) {
+            throw new Error(`release-packages.json: ${name} missing required source/asset.`);
+        }
+        const releases = await fetchReleases(entry.source);
+        let kept = 0;
+        for (const rel of releases) {
+            const asset = (rel.assets || []).find((a) => a.name === entry.asset);
+            if (!asset) {
+                console.warn(`  skip ${name}@${rel.tag_name}: asset "${entry.asset}" not in release.`);
+                continue;
+            }
+            const tag = rel.tag_name;
+            // Composer's version constraint engine expects a numeric-ish
+            // version; preserve the raw tag in the dist URL so it still
+            // resolves to the right release asset.
+            const version = tag.startsWith('v') ? tag.slice(1) : tag;
+            synthesised.push({
+                type: 'package',
+                package: {
+                    name,
+                    version,
+                    type: entry.type || 'wordpress-plugin',
+                    dist: {
+                        type: 'zip',
+                        url: asset.browser_download_url,
+                    },
+                    ...(entry.require ? { require: entry.require } : {}),
+                    ...(entry.homepage ? { homepage: entry.homepage } : {}),
+                },
+            });
+            kept++;
+        }
+        console.log(`${name}: ${kept} versions (from ${releases.length} stable releases).`);
+    }
+
+    satis.repositories = (satis.repositories || []).concat(synthesised);
+    fs.writeFileSync(OUT_PATH, JSON.stringify(satis, null, 4));
+    console.log(`Wrote ${OUT_PATH} with ${synthesised.length} synthesised package entries.`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/release-packages.json
+++ b/release-packages.json
@@ -1,0 +1,7 @@
+{
+    "altcha-org/altcha": {
+        "source": "altcha-org/altcha-wordpress-next",
+        "asset": "altcha.zip",
+        "type": "wordpress-plugin"
+    }
+}


### PR DESCRIPTION
## Summary

Adds a second mechanism for exposing plugins through this satis: direct GitHub-release mirroring, for upstreams that already publish a versioned release zip and don't need a Genero-owned fork.

Motivated by [altcha-org/altcha-wordpress-next](https://github.com/altcha-org/altcha-wordpress-next), which ships compiled JS assets (\`public/vendor/admin-app.min.js\` and friends) only in the release zip — its git source lacks them, so the existing VCS pattern can't be used.

## How it works

1. **\`release-packages.json\`** declares which packages we mirror:

    \`\`\`json
    {
        "altcha-org/altcha": {
            "source": "altcha-org/altcha-wordpress-next",
            "asset":  "altcha.zip",
            "type":   "wordpress-plugin"
        }
    }
    \`\`\`

2. **\`generate-release-packages.js\`** runs before satis build. For each entry it queries the GitHub API for stable releases, finds the named asset, and emits one \`package\`-type repository entry per release:

    \`\`\`json
    {
        "type": "package",
        "package": {
            "name": "altcha-org/altcha",
            "version": "3.0.1",
            "type": "wordpress-plugin",
            "dist": {
                "type": "zip",
                "url": "https://github.com/altcha-org/altcha-wordpress-next/releases/download/v3.0.1/altcha.zip"
            }
        }
    }
    \`\`\`

3. The synthesised entries get merged into \`satis.json\`, written to \`satis.merged.json\` (gitignored), and \`composer/satis build\` runs against the merged file. Existing VCS entries are untouched; \`rewrite-dist-urls.js\` still runs after build for the fork-pattern packages.

## Auto-updates

Added a daily cron (\`30 4 * * *\` UTC) so new upstream releases are picked up automatically. The existing event triggers (\`workflow_call\`, \`workflow_dispatch\`, \`repository_dispatch\`, \`push\`) wouldn't catch new releases on third-party repos.

## Validation

Ran the generator locally against \`altcha-org/altcha-wordpress-next\`:

\`\`\`
altcha-org/altcha: 26 versions (from 26 stable releases).
Wrote satis.merged.json with 26 synthesised package entries.

first entry:
  altcha-org/altcha@3.0.1, type=wordpress-plugin
  dist=https://github.com/altcha-org/altcha-wordpress-next/releases/download/v3.0.1/altcha.zip

all versions: 3.0.1, 3.0.0, 2.6.1, 2.6.0, 2.5.0, 2.4.2, 2.4.1, 2.4.0, 2.3.1,
              2.3.0, 2.2.0, 2.1.2, 2.1.1, 2.1.0, 2.0.11, 2.0.10, 2.0.9,
              2.0.8, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0.0
\`\`\`

## When to use which mechanism

| Genero-owned fork (existing) | Direct GitHub-release mirror (new) |
|---|---|
| Need version-specific \`composer.json\` (per-version \`require\`, autoload, etc.) | Constant metadata across versions, no per-tag tweaks |
| Need to inject license keys / private commits | Upstream publishes signed zips directly |
| Want a stable mirror independent of upstream availability | Trust upstream's GitHub releases as canonical |
| Examples: gds-assistant, advanced-custom-fields-pro, polylang-pro | First entry: altcha-org/altcha |

Both pipelines stay; README documents the distinction.

## Test plan

- [x] Generator output validated locally — 26 packages synthesised, dist URLs verified against the actual release-asset endpoints.
- [x] Generator handles drafts/prereleases (filtered) and missing assets per release (warned + skipped).
- [ ] After merge: trigger Satis Build via Actions tab, then \`curl https://generoi.github.io/packagist/p2/altcha-org/altcha.json\` should list all 26 versions.
- [ ] Add \`altcha-org/altcha:^3.0\` in snellmanrecipes \`composer.json\` (follow-up PR there).