### PR TITLE
Add generoi/gravityforms-altcha to satis

### DIFF
--- a/release-dist.json
+++ b/release-dist.json
@@ -1,3 +1,4 @@
 {
-    "generoi/gds-assistant": "https://github.com/generoi/gds-assistant/releases/download/{tag}/gds-assistant.zip"
+    "generoi/gds-assistant": "https://github.com/generoi/gds-assistant/releases/download/{tag}/gds-assistant.zip",
+    "generoi/gravityforms-altcha": "https://github.com/generoi/gravityforms-altcha/releases/download/{tag}/gravityforms-altcha.zip"
 }

--- a/satis.json
+++ b/satis.json
@@ -19,6 +19,7 @@
         { "type": "vcs", "url": "https://github.com/generoi/gf-pardot-pro.git" },
         { "type": "vcs", "url": "https://github.com/generoi/gf-pipedrive-crm-perks-pro.git" },
         { "type": "vcs", "url": "https://github.com/generoi/gravityforms.git" },
+        { "type": "vcs", "url": "https://github.com/generoi/gravityforms-altcha.git" },
         { "type": "vcs", "url": "https://github.com/generoi/gravityforms-elisadesk.git" },
         { "type": "vcs", "url": "https://github.com/generoi/gravityformsactivecampaign.git" },
         { "type": "vcs", "url": "https://github.com/generoi/gravityformsakismet.git" },


### PR DESCRIPTION
## Summary

Registers the new [generoi/gravityforms-altcha](https://github.com/generoi/gravityforms-altcha) plugin in this satis. MIT-licensed, public, invisible ALTCHA proof-of-work spam protection for Gravity Forms.

## Changes

- \`satis.json\`: new VCS entry for \`generoi/gravityforms-altcha.git\`.
- \`release-dist.json\`: rewrites the satis dist URL to the GitHub release zip (since \`build/widget.js\` is only present in the release artifact, not in git).

## Validation

- Plugin's \`composer.json\` declares \`type: wordpress-plugin\`, so composer-installers + Bedrock's \`installer-paths\` route it to \`web/app/plugins/gravityforms-altcha/\`.
- v0.1.0 already tagged + released with attached \`gravityforms-altcha.zip\` asset: https://github.com/generoi/gravityforms-altcha/releases/tag/v0.1.0
- Test workflow green on the source repo.

After merge: the Satis Build workflow will run automatically, discover the new VCS entry, expose \`generoi/gravityforms-altcha\` via the index. Snellman PR follow-up will swap the third-party altcha plugin for this one.