### PR TITLE
Drop altcha-org/altcha mirror — name collision with upstream library

### DIFF
--- a/release-packages.json
+++ b/release-packages.json
@@ -1,7 +1,1 @@
-{
-    "altcha-org/altcha": {
-        "source": "altcha-org/altcha-wordpress-next",
-        "asset": "altcha.zip",
-        "type": "wordpress-plugin"
-    }
-}
+{}


### PR DESCRIPTION
## Summary

The synthesised mirror added in #4 exposed the proprietary \`altcha-wordpress-next\` release zips under package name **\`altcha-org/altcha\`** — same name as the MIT-licensed PHP library on packagist.

Composer's repository order makes this satis win for matching names: any consumer depending on the library (e.g. the new [generoi/gravityforms-altcha](https://github.com/generoi/gravityforms-altcha)) silently gets the **WordPress plugin** instead, with no \`AltchaOrg\\Altcha\\*\` classes available.

We've since replaced the snellmanrecipes use-case for the v3 plugin with our own MIT-licensed plugin, so the mirror is no longer needed. Drop it to free the name.

## What changes

\`release-packages.json\` is reset to \`{}\`. The pre-build synthesiser (\`generate-release-packages.js\`) becomes a no-op, and the existing infrastructure (cron, mechanism docs) stays in place for future use.

## If we need this again later

Re-register under a non-colliding name, e.g.:

\`\`\`json
{
    "altcha-org/altcha-wordpress-next": {
        "source": "altcha-org/altcha-wordpress-next",
        "asset":  "altcha.zip",
        "type":   "wordpress-plugin"
    }
}
\`\`\`

That matches the upstream repo name and avoids stealing names from packagist.