### PR TITLE
fix(satis): wipe stale p2/* metadata before publishing

### DIFF
--- a/.github/workflows/satis.yml
+++ b/.github/workflows/satis.yml
@@ -71,11 +71,14 @@ jobs:
         run: |
           rm composer.json satis.merged.json
           git checkout gh-pages
-          rm -rf include/*
+          # Wipe stale satis output so packages removed from satis.json (or
+          # release-packages.json) actually disappear from the index. Composer
+          # v2 metadata lives under p2/, v1 under include/.
+          rm -rf include/* p2/*
           cp -R ${{ env.BUILD_DIR }}/* .
           rm -rf ${{ env.BUILD_DIR }}/
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add .
+          git add -A
           git commit -m "Updated repository"
           git push


### PR DESCRIPTION
## Summary

Removed packages leave stale metadata behind in this satis. The publish step purges \`include/*\` (composer v1) before copying the fresh build output, but **not \`p2/*\`** (composer v2). So when a package is dropped from \`satis.json\` / \`release-packages.json\`, its \`p2/<vendor>/<name>.json\` file remains on \`gh-pages\` and composer keeps resolving it.

Hit this concretely with #6 — dropping the \`altcha-org/altcha\` mirror left the old metadata behind, and consumers were still pulling the WordPress plugin instead of the upstream library on packagist.

## Change

\`\`\`diff
-          rm -rf include/*
+          rm -rf include/* p2/*
\`\`\`

Also switches \`git add .\` to \`git add -A\` so deletions are committed alongside additions.

## After merge

The next Satis Build run will rebuild the gh-pages branch from scratch — \`p2/altcha-org/altcha.json\` (and any other stragglers) drops out for real.